### PR TITLE
Refactor NewManager to accept options for appID configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ func main() {
     // Initialize local JWKS provider
     jwksProvider := jwtauth.NewLocalJWKSProvider(jwksAdapter)
 
-    // Initialize JWT manager
-    jwtManager, err := jwtauth.NewManager(jwksProvider, "your-app-id")
+    // Initialize JWT manager without appID
+    jwtManager, err := jwtauth.NewManager(jwksProvider)
     if err != nil {
         log.Fatalf("failed to initialize JWT manager: %v", err)
     }
@@ -72,8 +72,8 @@ func main() {
     // Initialize remote JWKS provider
     remoteProvider := jwtauth.NewRemoteJWKSProvider("https://your-auth-server/.well-known/jwks.json")
 
-    // Initialize JWT manager
-    jwtManager, err := jwtauth.NewManager(remoteProvider, "your-app-id")
+    // Initialize JWT manager with appID
+    jwtManager, err := jwtauth.NewManager(remoteProvider, jwtauth.WithAppID("your-app-id"))
     if err != nil {
         log.Fatalf("failed to initialize JWT manager: %v", err)
     }

--- a/jwt_manager.go
+++ b/jwt_manager.go
@@ -30,18 +30,25 @@ type Manager struct {
 	appID string
 }
 
-func NewManager(jwksProvider JWKSProvider, appID string) (*Manager, error) {
-	if appID == "" {
-		return nil, fmt.Errorf("appID is required")
-	}
-
+func NewManager(jwksProvider JWKSProvider, opts ...Option) (*Manager, error) {
 	m := &Manager{
 		jwksProvider: jwksProvider,
 		jwksCache:    cache.New(),
-		appID:        appID,
+	}
+
+	for _, opt := range opts {
+		opt(m)
 	}
 
 	return m, nil
+}
+
+type Option func(*Manager)
+
+func WithAppID(appID string) Option {
+	return func(m *Manager) {
+		m.appID = appID
+	}
 }
 
 const (


### PR DESCRIPTION
Refactor NewManager to accept options for appID configuration, enhancing flexibility in JWT manager initialization. Update README examples to reflect new usage without mandatory appID.